### PR TITLE
Argument passing, run user programs from disk, cosmetic changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,13 @@ DOS	= \
 	dos/cmd_keys.asm \
 	dos/cmd_exec.asm \
 	dos/cmd_wifi.asm \
+	dos/cmd_external.asm \
 	dos/strings.asm \
 	dos/display.asm \
 	dos/readline.asm \
 	dos/reader.asm \
-	kernel/api.asm
+	kernel/api.asm \
+	kernel/keys.asm
 
 COPT = -C -Wall -Werror -Wno-shadow -x --verbose-list -I .
 

--- a/dos/cmd_dir.asm
+++ b/dos/cmd_dir.asm
@@ -52,6 +52,7 @@ cmd
             stz     stop
 
           ; Set the drive
+            lda     #1  ; Token #1
             jsr     readline.parse_drive
             sta     kernel.args.directory.open.drive
 
@@ -218,33 +219,13 @@ print_ext
     ; TODO: overlay the appropriate struct and read the members.
 
             lda     buf+1
-            jsr     print_hex
+            jsr     display.print_hex
 
             lda     buf+0
-            jsr     print_hex
+            jsr     display.print_hex
 
             rts
 
-
-print_hex
-            pha
-            lsr     a
-            lsr     a
-            lsr     a
-            lsr     a
-            jsr     _digit
-            pla
-            and     #$0f
-            jsr     _digit
-            rts
-_digit
-            phy
-            tay
-            lda     _digits,y
-            ply
-            jmp     putc
-_digits                             
-            .text   "0123456789abcdef"
 
             .send
             .endn

--- a/dos/cmd_dump.asm
+++ b/dos/cmd_dump.asm
@@ -25,7 +25,7 @@ cmd
             jmp     reader.read_file
             
 print
-            jsr     print_hex
+            jsr     display.print_hex
             jsr     print_space
             dec     count
             bne     _done
@@ -38,26 +38,6 @@ _done
 print_space
             lda     #' ' 
             jmp     putc
-
-print_hex
-            pha
-            lsr     a
-            lsr     a
-            lsr     a
-            lsr     a
-            jsr     _digit
-            pla
-            and     #$0f
-            jsr     _digit
-            rts
-_digit
-            phy
-            tay
-            lda     _digits,y
-            ply
-            jmp     putc
-_digits                             
-            .text   "0123456789abcdef"
 
             .send
             .endn

--- a/dos/cmd_exec.asm
+++ b/dos/cmd_exec.asm
@@ -2,8 +2,6 @@
 
 exec        .namespace
 
-            .mkstr      desc,  "This program shows the held status of keys.  Press <ENTER> to quite."
-
             .section    dp
 addr        .word       ?
             .send

--- a/dos/cmd_external.asm
+++ b/dos/cmd_external.asm
@@ -1,0 +1,314 @@
+            .cpu    "65c02"
+
+external    .namespace
+
+            .mkstr      not_executable, "File is not executable."
+
+
+header_t    .struct
+sig_f2      .byte   ?
+sig_56      .byte   ?
+blocks      .byte   ?
+start_slot  .byte   ?
+entry       .word   ?
+            .fill   4
+size        .ends
+
+            .section    data
+success     .byte       ?
+stream      .byte       ?
+remaining   .word       ?
+when_done   .word       ?
+header      .dstruct    header_t
+            .send
+
+
+            .section    code
+
+cmd
+          ; Initialize to "no stream"
+            stz     stream
+
+          ; Indicate fail until we know better
+            stz     success
+
+          ; Set the drive
+            lda     drive
+            sta     kernel.args.file.open.drive
+
+          ; Set the filename (conveniently aligned)
+            lda     readline.tokens+0
+            sta     kernel.args.file.open.fname+0            
+            lda     #>readline.buf
+            sta     kernel.args.file.open.fname+1
+
+          ; Set the filename length
+            lda     #0  ; Token #0
+            jsr     readline.token_length
+            beq     _handle_not_found
+            sta     kernel.args.file.open.fname_len
+
+          ; Set the mode and open
+            lda     #kernel.args.file.open.READ
+            sta     kernel.args.file.open.mode
+            jsr     kernel.File.Open
+            bcs     _handle_not_found
+
+          ; Fall through to event loop and load the executable
+
+_event_loop
+            jsr     kernel.NextEvent
+            bcs     _event_loop
+
+    .if false
+            lda     #'>'
+            jsr     display.putchar
+            lda     event.type
+            jsr     display.print_hex
+            jsr     put_cr
+    .endif
+
+            lda     event.type
+
+            cmp     #kernel.event.key.PRESSED
+            beq     _handle_check_escape
+
+            cmp     #kernel.event.file.NOT_FOUND
+            beq     _handle_not_found
+            cmp     #kernel.event.file.ERROR
+            beq     _handle_not_found
+
+            cmp     #kernel.event.file.OPENED
+            beq     _handle_opened
+            cmp     #kernel.event.file.DATA
+            beq     _handle_data_read
+            cmp     #kernel.event.file.CLOSED
+            beq     _handle_file_closed
+            cmp     #kernel.event.file.EOF
+            beq     _handle_eof
+
+            bra     _event_loop
+
+
+_handle_not_found
+            sec
+            rts
+
+
+_handle_check_escape
+            lda     event.key.raw
+            cmp     #ESC
+            bne     _event_loop
+            jmp     _close_file
+
+
+_handle_file_closed
+            lda     success
+            beq     _exit_good
+            jmp     _start_program
+_exit_good
+            clc
+            rts
+
+
+_handle_opened
+          ; Read file header
+            lda     event.file.stream
+            sta     stream
+
+            lda     #<header
+            sta     kernel.args.buf
+            lda     #>header
+            sta     kernel.args.buf+1
+
+            lda     #<_handle_header_read
+            sta     when_done
+            lda     #>_handle_header_read
+            sta     when_done+1
+
+            lda     #<header_t.size
+            sta     remaining
+            stz     remaining+1
+
+            jmp     _start_read
+
+
+_handle_data_read
+          ; Some data has been read from file
+    .if false
+            lda     #'-'
+            jsr     putc
+            lda     event.file.data.read
+            jsr     display.print_hex
+            jsr     put_cr
+    .endif
+
+            lda     event.file.data.read
+            sta     kernel.args.buflen
+            
+            jsr     kernel.ReadData
+
+          ; Advance destination pointer
+            clc
+            lda     kernel.args.buf
+            adc     kernel.args.buflen
+            sta     kernel.args.buf
+            bcc     _skip_inc
+            inc     kernel.args.buf+1
+_skip_inc
+
+          ; Decrement remaining count
+            sec
+            lda     remaining
+            sbc     kernel.args.buflen
+            sta     remaining
+            lda     remaining+1
+            sbc     #0
+            sta     remaining+1
+
+          ; Continue read if not all bytes read
+            lda     remaining
+            ora     remaining+1
+            beq     _handle_eof
+            jmp     _start_read
+
+_handle_eof
+          ; Reading done, continue
+            jmp     (when_done)
+
+
+_handle_header_read
+          ; Header has been read, does the magic number match?
+            lda     header.sig_f2
+            cmp     #$f2
+            bne     _not_executable
+            lda     header.sig_56
+            cmp     #$56
+            beq     _is_executable
+
+          ; Not executable, close file
+_not_executable
+            lda     #not_executable_str
+            jsr     puts_cr
+            bra     _close_file
+_is_executable
+          ; File is executable, load rest into memory
+            lda     #header_t.size
+            sta     kernel.args.buf
+            lda     header.start_slot
+            asl     a
+            asl     a
+            asl     a
+            asl     a
+            asl     a
+            sta     kernel.args.buf+1
+
+            lda     header.blocks
+            asl     a
+            asl     a
+            asl     a
+            asl     a
+            asl     a
+            stz     remaining
+            sta     remaining+1
+
+            lda     #<_handle_exe_read
+            sta     when_done
+            lda     #>_handle_exe_read
+            sta     when_done+1
+
+            jmp     _start_read
+
+
+_handle_exe_read
+            lda     #$ff
+            sta     success
+            
+            ; fall through to _close_file
+_close_file
+            lda     stream
+            bne     _close_good
+            clc
+            rts
+_close_good            
+            sta     kernel.args.file.close.stream 
+            jsr     kernel.File.Close
+
+            jmp     _event_loop
+
+
+_start_program
+        .if false
+            lda     #'!'
+            jsr     putc
+            jsr     put_cr
+        .endif
+
+
+          ; Run program
+            jsr     _start_enter
+            bcc     _exited_reinit
+
+          ; Carry set, reset machine
+            stz     $01
+            lda     #$DE
+            sta     $D6A2
+            lda     #$AD
+            sta     $D6A3
+            lda     #$80
+            sta     $D6A0
+            stz     $D6A0
+_spin       bra     _spin   ; wait for reset
+
+_exited_reinit
+          ; Reinitialize essential DOS functionality.
+            jsr     kernel.Display.Reset
+            jsr     display.init
+            jsr     display.cls
+
+          ; Tell the event call where to dump events.
+            lda     #<event
+            sta     kernel.args.events+0
+            lda     #>event
+            sta     kernel.args.events+1
+
+            clc
+            rts
+_start_enter
+            jmp     (header.entry)
+
+
+_start_read
+    .if false
+            lda     #'+'
+            jsr     putc
+            lda     remaining+1
+            jsr     display.print_hex
+            lda     remaining
+            jsr     display.print_hex
+            jsr     put_cr
+    .endif
+
+          ; Set read length, max 128 bytes at a time
+            lda     remaining+1
+            bne     _limit_read
+            lda     remaining
+            bpl     _read_len_good
+_limit_read
+            lda     #128
+_read_len_good
+            sta     kernel.args.file.read.buflen
+
+          ; Set stream id and start read
+            lda     stream
+            sta     kernel.args.file.read.stream
+
+            jsr     kernel.File.Read
+            bcs     _close_file
+
+            jmp     _event_loop
+
+
+            .send
+            .endn
+

--- a/dos/cmd_keys.asm
+++ b/dos/cmd_keys.asm
@@ -32,9 +32,9 @@ _loop
 _joy
             ldx     #0
             lda     event.joystick.joy0
-            jsr     print_hex
+            jsr     display.print_hex
             lda     event.joystick.joy1
-            jsr     print_hex
+            jsr     display.print_hex
             bra     _loop
 
 _released
@@ -60,27 +60,6 @@ _done
             clc
             rts
 
-print_hex
-            pha
-            lsr     a
-            lsr     a
-            lsr     a
-            lsr     a
-            jsr     _digit
-            pla
-            and     #$0f
-            jsr     _digit
-            rts
-_digit
-            phy
-            tay
-            lda     _digits,y
-            ply
-            sta     $c000,x
-            inx
-            rts
-_digits                             
-            .text   "0123456789abcdef"
 
             .send
             .endn

--- a/dos/cmd_write.asm
+++ b/dos/cmd_write.asm
@@ -18,6 +18,7 @@ cmd
             bne     _done
 
           ; Set the drive
+            lda     #1  ; Token #1
             jsr     readline.parse_drive
             sta     kernel.args.file.open.drive
 

--- a/dos/display.asm
+++ b/dos/display.asm
@@ -13,7 +13,6 @@ display     .namespace
 src         .word   ?
 dest        .word   ?
 len         .byte   ?
-line_ptr    .word   ?
 cur_line    .byte   ?
 scroll      .byte   ?
 
@@ -21,7 +20,6 @@ color       .byte   ?
 curcol      .byte   ?
 cursor      .byte   ?
 screen      .word   ?
-str         .word   ?
             .send
 
 TEXT_LUT_FG = $d800
@@ -43,6 +41,8 @@ init
             sta     io_ctrl
 
             rts
+
+
 
 set_cursor
         jsr     cursor_off
@@ -73,7 +73,29 @@ update_cursor
         sty     io_ctrl
         ply
         rts
-        
+
+
+print_hex
+            pha
+            lsr     a
+            lsr     a
+            lsr     a
+            lsr     a
+            jsr     _digit
+            pla
+            and     #$0f
+            jsr     _digit
+            rts
+_digit
+            phy
+            tay
+            lda     _digits,y
+            ply
+            jmp     putc
+_digits                             
+            .text   "0123456789abcdef"
+
+
 putchar
         pha
         phy

--- a/dos/dos.asm
+++ b/dos/dos.asm
@@ -43,7 +43,11 @@ mmu         .fill       8
             .cerror * > $00ff, "Out of dp space."
             .endv
 
-            .virtual    $0200   ; Application memory
+            .virtual    $0200
+            .dsection   kupdata ; Data transferable to Kernel User Programs
+            .endv
+
+            .virtual    $0300   ; Application memory
             .dsection   pages   ; Aligned segments
             .endv
 
@@ -81,64 +85,13 @@ soft
             jmp     cmd.start
 	
 welcome
-            jsr     hardware
-            jsr     ukernel
-            jsr     fat32
-            rts
+            lda     #>_msg
+            ldx     #<_msg
+            jmp     strings.puts_zero
 
-hardware            
-            phy
-            ldy     #0
-_loop       lda     _msg,y
-            beq     _done
-            jsr     putc
-            iny
-            bra     _loop
-_done
-            ply
-            rts        
-_msg
-            .text   "Foenix F256 by Stefany Allaire", $0a
-            .text   "https://c256foenix.com/f256-jr",$0a
-            .text   $0a, $00
-
-ukernel            
-            phy
-            ldy     #0
-_loop       lda     _msg,y
-            beq     _done
-            jsr     putc
-            iny
-            bra     _loop
-_done
-            ply
-            rts        
-_msg
-            .text   "TinyCore MicroKernel", $0a
-            .text   "Copyright 2022 Jessie Oberreuter", $0a
-            .text   "Gadget@HackwrenchLabs.com",$0a
-            .text   "F256 Edition built ", DATE_STR, $0a
-            .text   $0a, $00
-
-fat32
-            phy
-            ldy     #0
-_loop       lda     _msg,y
-            beq     _done
-            jsr     putc
-            iny
-            bra     _loop
-_done
-            ply
-            rts        
-_msg
-            .text   "Fat32 from https://github.com/commanderx16/x16-rom", $0a
-            .text   "Copyright 2020 Frank van den Hoef and Michael Steil", $0a
-            .text   $0a
-            .text   "Simple DOS Shell, built ", DATE_STR, $0a
-            .text   $0a
-            .byte   $0
+_msg        .text   "Foenix F256 DOS Shell (", DATE_STR, ")", $0a, $0a, 0
             
+
 basic
             lda     #<_basic
             sta     kernel.args.buf+0

--- a/dos/reader.asm
+++ b/dos/reader.asm
@@ -31,6 +31,7 @@ read_file
             stz     stop
 
           ; Set the drive 
+            lda     #1  ; Token #1
             jsr     readline.parse_drive
             sta     kernel.args.file.open.drive
 
@@ -63,6 +64,8 @@ _loop
             beq     _done
             cmp     #kernel.event.file.NOT_FOUND
             beq     _not_found
+            cmp     #kernel.event.file.ERROR
+            beq     _not_found
 
             jsr     _dispatch
             bra     _loop
@@ -78,8 +81,6 @@ _dispatch
             beq     _read
             cmp     #kernel.event.file.DATA
             beq     _data
-            cmp     #kernel.event.file.ERROR
-            beq     _eof
             cmp     #kernel.event.file.EOF
             beq     _eof
             cmp     #kernel.event.key.PRESSED

--- a/dos/strings.asm
+++ b/dos/strings.asm
@@ -27,15 +27,14 @@ puts_cr
             jsr     puts
             jmp     put_cr
 
-puts
+puts_zero
+        ; Input - XA string            
+            phx
             phy
 
-            tay
-            lda     Strings+0,y
-            sta     strings.str+0
-            lda     Strings+1,y
+            stx     strings.str+0
             sta     strings.str+1
-            
+
             ldy     #0
 _loop
             lda     (strings.str),y
@@ -44,6 +43,19 @@ _loop
             iny
             bra     _loop
 _done
+            ply
+            plx
+            clc
+            rts            
+
+puts
+            phy
+
+            tay
+            ldx     Strings+0,y
+            lda     Strings+1,y
+            jsr     puts_zero
+            
             ply
             clc
             rts            


### PR DESCRIPTION
This PR adds the ability to load and execute kernel user programs from disk. Also implemented is a method of passing arguments to user programs, either on disk or resident in flash. Lastly, most of the verbose welcome message has been moved to an `about` command.